### PR TITLE
Fix links in past issues

### DIFF
--- a/site/content/2022-08-26.md
+++ b/site/content/2022-08-26.md
@@ -8,7 +8,7 @@ podcast: 23bdf9e6
 ---
 ## Topics
 ### Heroku ends free tier
-<small>Submitted by: [jonafato](https://api.github.com/users/jonafato) on 2022-08-26T17:47:10Z</small>
+<small>Submitted by: [jonafato](https://github.com/jonafato) on 2022-08-26T17:47:10Z</small>
 
 URL: https://blog.heroku.com/next-chapter
 
@@ -16,7 +16,7 @@ Heroku is ending its free tier and plans to remove "inactive" accounts.
 
 
 ### Phishing attack targeting PyPI users
-<small>Submitted by: [jonafato](https://api.github.com/users/jonafato) on 2022-08-26T17:19:18Z</small>
+<small>Submitted by: [jonafato](https://github.com/jonafato) on 2022-08-26T17:19:18Z</small>
 
 URL: https://twitter.com/pypi/status/1562442188285308929
 
@@ -24,14 +24,14 @@ A phishing attack has targeted maintainers of projects hosted on https://pypi.or
 
 
 ### Python’s still No. 1, but employers love to see SQL skills
-<small>Submitted by: [kjaymiller](https://api.github.com/users/kjaymiller) on 2022-08-26T15:58:45Z</small>
+<small>Submitted by: [kjaymiller](https://github.com/kjaymiller) on 2022-08-26T15:58:45Z</small>
 
 URL: https://spectrum.ieee.org/top-programming-languages-2022
 
 Python's position w/e but I would like to learn more about why it's not as appealing as SQL/Java in job hunt, especially when we have solid ORMs. (The Java thing is just legacy IMHO)
 
 ### KiwiPy Talks are Now Available
-<small>Submitted by: [kjaymiller](https://api.github.com/users/kjaymiller) on 2022-08-26T15:49:42Z</small>
+<small>Submitted by: [kjaymiller](https://github.com/kjaymiller) on 2022-08-26T15:49:42Z</small>
 
 You can now watch the KiwiPy talks on YouTube!
 

--- a/site/content/2022-09-02.md
+++ b/site/content/2022-09-02.md
@@ -11,7 +11,7 @@ github: https://github.com/kjaymiller/Python-Community-News/blob/main/app/conten
 
 ### Python Packaging Survey
 
-<small>Submitted by: [jonafato](https://api.github.com/users/jonafato) on 2022-09-01T20:26:14Z</small>
+<small>Submitted by: [jonafato](https://github.com/jonafato) on 2022-09-01T20:26:14Z</small>
 
 The Python Software Foundation announced on [Twitter](https://twitter.com/ThePSF/status/1565415698100359169) they're running a Python Packaging Authority survey to "better understand the challenges and opportunities within the Python packaging ecosystem.".
 The Python Packaging Authority (PyPA) is a working group that maintains a core set of software projects used in Python packaging.
@@ -21,7 +21,7 @@ The PSF will publish a packaging vision and mission document informed by survey 
 
 ### DjangoCon Announces Weekly Twitter Spaces, Virtual Only Talks, and their COVID Policy
 
-<small>Submitted by: [kjaymiller](https://api.github.com/users/kjaymiller) on 2022-08-31T22:19:13Z</small>
+<small>Submitted by: [kjaymiller](https://github.com/kjaymiller) on 2022-08-31T22:19:13Z</small>
 
 The DjangoCon US Organizers plan to hold weekly Twitter spaces leading up to their upcoming conference in October. During this space, lead by Django Events Foundation of North America board members and Conference planners, the team [announced](https://twitter.com/djangocon/status/1565025875904454656) an in-person COVID policy, including mask and vaccine requirements. The mandate can be found at https://2022.djangocon.us/covid/.
 Another topic that came out of the space was there would be exclusive talks given on the virtual platform.
@@ -31,7 +31,7 @@ Django Events Foundation of North America cofounder and former President Jeff Tr
 
 ### Starlite looking for Maintainers and Contributors
 
-<small>Submitted by: [kjaymiller](https://api.github.com/users/kjaymiller) on 2022-08-30T06:37:21Z</small>
+<small>Submitted by: [kjaymiller](https://github.com/kjaymiller) on 2022-08-30T06:37:21Z</small>
 
 The maintainer of Starlite made a plea to the community looking for maintainers and organizers. This seemed to receive positive feedback as many folks offered to help.
 The maintainer claimed that:

--- a/site/content/2022-09-09.md
+++ b/site/content/2022-09-09.md
@@ -8,47 +8,47 @@ github: https://github.com/kjaymiller/Python-Community-News/blob/main/app/conten
 
 ## Topics
 
-### [California Passes Law Requiring Companies to Post Salary Ranges on Job Listings](https://api.github.com/users/jonafato)
+### [California Passes Law Requiring Companies to Post Salary Ranges on Job Listings](https://github.com/jonafato)
 
-<small>Submitted by: [jonafato](https://api.github.com/users/jonafato) on 2022-09-06T23:06:52Z</small>
+<small>Submitted by: [jonafato](https://github.com/jonafato) on 2022-09-06T23:06:52Z</small>
 
 California has passed a law requiring companies to post salary ranges with job postings. The law also requires companies with more than 100 employees to publish data about their racial and gender pay gaps. It now goes to the Governor to sign or veto by the end of September. Colorado, Washington, and New York City have similar salary posting laws in place, and the New York State legislature has passed one that is now awaiting the Governor's signature.
 
 
-### [India Tech Hub hit with massive flood and outages ](https://api.github.com/users/kjaymiller)
+### [India Tech Hub hit with massive flood and outages ](https://github.com/kjaymiller)
 
-<small>Submitted by: [kjaymiller](https://api.github.com/users/kjaymiller) on 2022-09-06T12:01:12Z</small>
+<small>Submitted by: [kjaymiller](https://github.com/kjaymiller) on 2022-09-06T12:01:12Z</small>
 
 Many parts of the city, dubbed India’s tech capital, were under water for a second day on Tuesday as more rain fell in an unusually wet monsoon season.  The southern Indian city of Bengaluru after dealt with two days of torrential rains, setting off long traffic snarls, widespread power outages and heavy floods.
 This weather compounds with the complaints from companies that infrastructure development has not kept up with the massive boom to population in the area post-COVID.
 
 
-### [fast-math compiler options result in incorrect math results](https://api.github.com/users/crazy4pi314)
+### [fast-math compiler options result in incorrect math results](https://github.com/crazy4pi314)
 
-<small>Submitted by: [crazy4pi314](https://api.github.com/users/crazy4pi314) on 2022-09-07T16:33:01Z</small>
+<small>Submitted by: [crazy4pi314](https://github.com/crazy4pi314) on 2022-09-07T16:33:01Z</small>
 
 Fast math compilation options lead to incorrect floating point math results. When you use gcc to compile, you can use an option to ask it to drop precision to speed up the compilation, but when the shared library is loaded it also sets a CPU flag to use less numerically precise methods for speed. This flag should only be set during compilation, and not carry to the produced code. The linked blog post investigates packages on pip and found 2500 packages that exhibit the degraded numerical precision if complied fast.
 
 
-### [Python 3.10.7 Released](https://api.github.com/users/kjaymiller)
+### [Python 3.10.7 Released](https://github.com/kjaymiller)
 
-<small>Submitted by: [kjaymiller](https://api.github.com/users/kjaymiller) on 2022-09-07T19:24:55Z</small>
+<small>Submitted by: [kjaymiller](https://github.com/kjaymiller) on 2022-09-07T19:24:55Z</small>
 
 [Python releases 3.10.7, 3.9.14, 3.8.14, and 3.7.14 are now available](https://pythoninsider.blogspot.com/2022/09/python-releases-3107-3914-3814-and-3714.html)
 This bugfix version of Python was released out-of-schedule to address [CVE-2020-10735](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-10735).
 The update changes how converting between integers and strings in bases other than binary, octal, hexadecimal, and base 32. If the number of digits in string form is above a limit a ValueError is now raised to avoid potential denial of service attacks due to the algorithmic complexity. This setting limit can be configured or disabled by environment variable, command line flag, or sys APIs. See the [integer string conversion length limitation](https://docs.python.org/release/3.10.7/library/stdtypes.html#int-max-str-digits) documentation.
 
 
-### [Lightbend ditches Apache 2 license – Chooses BSL](https://api.github.com/users/kjaymiller)
+### [Lightbend ditches Apache 2 license – Chooses BSL](https://github.com/kjaymiller)
 
-<small>Submitted by: [kjaymiller](https://api.github.com/users/kjaymiller) on 2022-09-07T23:19:22Z</small>
+<small>Submitted by: [kjaymiller](https://github.com/kjaymiller) on 2022-09-07T23:19:22Z</small>
 
 Lightened the company behind the micro services platform Akka has changed the license to BSL-1, moving away from the Apache2 License. The 13 year old product will remain free for testing and other-non-production uses but require a commercial license for use in production. Businesses making less that $25 million in annual revenue will be able to receive the license free of charge.
 
 
-### [OSS-Fuzz finds a command injection bug in TinyGLTF](https://api.github.com/users/jonafato)
+### [OSS-Fuzz finds a command injection bug in TinyGLTF](https://github.com/jonafato)
 
-<small>Submitted by: [jonafato](https://api.github.com/users/jonafato) on 2022-09-09T02:28:46Z</small>
+<small>Submitted by: [jonafato](https://github.com/jonafato) on 2022-09-09T02:28:46Z</small>
 
 [OSS-Fuzz](https://google.github.io/oss-fuzz/), Google's service for fuzz-testing open source software, has identified a command injection vulnerability in [TinyGLTF](https://github.com/syoyo/tinygltf), which has since been patched. OSS-Fuzz has been operating since 2016 and began adding new "sanitizers" in December, 2021, one of which detected the bug in question. The project is accepting new sanitizers and offering rewards of $11,337 for integrations that identify two or more vulnerabilities in existing OSS-Fuzz projects. OSS-Fuzz supports projects written in several programming languages, including Python
 


### PR DESCRIPTION
The GitHub user account links currently link to the API rather than the GitHub user profile page. This change bulk updates these links to point to the correct pages.