### PR TITLE
Build the site as a test on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test site build on Pull Requests
+
+on:
+  pull_request:
+
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Build the site with RenderEngine
+        working-directory: site
+        run: python __init__.py

--- a/site/__init__.py
+++ b/site/__init__.py
@@ -1,4 +1,4 @@
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from render_engine.blog import Blog
 from render_engine.page import Page
 from render_engine.site import Site
@@ -17,7 +17,10 @@ class Site(Site):
         "YOUTUBE_URL": "https://www.youtube.com/channel/UCA8N-T_aEhHLzwwn47K-UFw",
     }
 
-    engine = Environment(loader=FileSystemLoader(["site/templates", "templates"]))
+    engine = Environment(
+        loader=FileSystemLoader(["site/templates", "templates"]),
+        undefined=StrictUndefined,
+    )
 
 
 if __name__ == "__main__":

--- a/site/templates/new_post.html
+++ b/site/templates/new_post.html
@@ -4,7 +4,7 @@
 {% block content %}
 <article class="prose">
 
-<h1 class="title text-2xl font-bold">{{title}}<small class="px-3"><a href="{{github}}">[edit]</a></small></h1>
+<h1 class="title text-2xl font-bold">{{title}}</h1>
 <iframe width="100%" height="180" frameborder="no" scrolling="no" seamless src="https://share.transistor.fm/e/{{podcast}}"></iframe>
 {{content}}
 <iframe width="560" height="315" src="https://www.youtube.com/embed/{{youtube}}" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>


### PR DESCRIPTION
This new action performs most of the same steps as the pages action, but it does aim to publish anything. The goal here is to ensure that we have some automated verification that new changes do not break the site before merging.

This also configures the jinja environment to process templates more strictly, causing erroneous template tags to raise an error in the build process instead of failing silently.