### PR TITLE
Ensure that pre-commit is run for PRs and on the main branch

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,21 @@
+name: Lint
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  lint-with-pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+
+      - name: Install pre-commit
+        run: pip install pre-commit
+
+      - name: Run pre-commit hooks
+        run: pre-commit run --all-files

--- a/publish/add_episode_from_issue.py
+++ b/publish/add_episode_from_issue.py
@@ -10,9 +10,11 @@ PCN = Repo("python-community-news", "topics")
 
 
 def run(issue_number: int):
-    template = environment.get_template('page_template.md')
+    template = environment.get_template("page_template.md")
     current_issue = Issue.from_issue_number(repo=PCN, issue_number=issue_number)
-    return pathlib.Path(f"site/content/{current_issue.episode_date}.md").write_text(template.render(issue=current_issue))
+    return pathlib.Path(f"site/content/{current_issue.episode_date}.md").write_text(
+        template.render(issue=current_issue)
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This change uses pre-commit as a linter / validation tool and will cause PR checks to fail any time a pre-commit task raises an error.

I plan to follow this up with a GitHub action that applies any automated formatting and fixes without requiring end-users to take additional action on a pull request, but this validation action is a good first step.