### PR TITLE
fix template "PY" and name in last episodes

### DIFF
--- a/publish/page_template.md
+++ b/publish/page_template.md
@@ -1,5 +1,5 @@
 ---
-title: {{issue.title}} - PYthon Community News {{issue.episode_date}}
+title: {{issue.title}} - Python Community News {{issue.episode_date}}
 slug: "{{issue.episode_date}}"
 date: {{issue._created_at}}
 podcast: {{issue.podcast}}

--- a/site/content/2022-10-28.md
+++ b/site/content/2022-10-28.md
@@ -1,5 +1,5 @@
 ---
-title: Python 3.11 is Out, Public Health News and New Systems and Proof-of-Concept Exploits! - PYthon Community News 2022-10-28
+title: Python 3.11 is Out, Public Health News and New Systems and Proof-of-Concept Exploits! - Python Community News 2022-10-28
 slug: "2022-10-28"
 date: 2022-10-29T00:06:28Z
 podcast: 2b6aa41a

--- a/site/content/2022-11-04.md
+++ b/site/content/2022-11-04.md
@@ -1,5 +1,5 @@
 ---
-title: Who "Owns" Open Source - PYthon Community News 2022-11-04
+title: Who "Owns" Open Source - Python Community News 2022-11-04
 slug: "2022-11-04"
 date: 2022-11-04T21:33:15Z
 podcast: 02c71267


### PR DESCRIPTION
The template had a typo that got into the last 2 archive entries. This fixes that.