### PR TITLE
More rss changes

### DIFF
--- a/site/__init__.py
+++ b/site/__init__.py
@@ -51,6 +51,14 @@ if __name__ == "__main__":
     class index(Page):
         template = "index.html"
 
+    @site.render_page
+    class rss_redirect_notice(Page):
+        template = "python-community-news-archive.rss"
+
+        @property
+        def url(self):
+            return Path("python-community-news-archive.rss")
+
     @site.render_collection
     class archive(Blog):
         has_archive = True

--- a/site/__init__.py
+++ b/site/__init__.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytailwindcss
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 from render_engine.blog import Blog
+from render_engine.feeds import RSSFeed
 from render_engine.page import Page
 from render_engine.site import Site
 
@@ -39,6 +40,10 @@ class Site(Site):
             )
 
 
+class Feed(RSSFeed):
+    extension = "xml"
+
+
 if __name__ == "__main__":
     site = Site(static="static")
 
@@ -53,3 +58,4 @@ if __name__ == "__main__":
         content_path = "./content"
         template = "new_post.html"
         archive_template: str = "archive.html"
+        feed = Feed

--- a/site/templates/base.html
+++ b/site/templates/base.html
@@ -8,6 +8,10 @@
             {% block header %}{% endblock %}
         {{ SITE_TITLE }}</title>
         <link rel="stylesheet" href="/static/style.css" />
+        <link rel="alternate"
+              type="application/rss+xml"
+              title="Python Community News Archive"
+              href="/python-community-news-archive.xml">
     </head>
     <body>
         <header class="bg-blue-500 p-5">

--- a/site/templates/base.html
+++ b/site/templates/base.html
@@ -32,7 +32,7 @@
                         <a href="/archive.html">Archive</a>
                     </h4>
                     <h4 class="mx-2 hover:underline">
-                        <a href="/python-community-news-archive.rss">RSS</a>
+                        <a href="/python-community-news-archive.xml">RSS</a>
                     </h4>
                 </nav>
             </div>

--- a/site/templates/python-community-news-archive.rss
+++ b/site/templates/python-community-news-archive.rss
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Python Community News - archive</title>
+    <link>https://pythoncommunitynews.com</link>
+    <description></description>
+    <atom:link href="https://pythoncommunitynews.com" rel="self" type="application/rss+xml" />
+
+<item>
+<title>The Python Community News Archive feed has moved</title>  <description><![CDATA[
+<p>The Python Community News Archive feed has moved. Please resubscribe at <a href="https://pythoncommunitynews.com/python-community-news-archive.xml">https://pythoncommunitynews.com/python-community-news-archive.xml</a>.<p>
+]]></description>
+
+    <link>
+      https://pythoncommunitynews.com/python-community-news-archive.xml
+    </link>
+<pubDate>Wednesday, 09 Nov 2022 00:00:00 -0500</pubDate></item></channel>
+</rss>


### PR DESCRIPTION
### Change .rss extension to .xml

My browser (at least when serving static files generated locally, tested
with both Firefox and Chrome) does not handle the link ending with
`.rss` as a normal xml file and instead attempts to download it. This
change overrides the base `RSSFeed` class to change the file extension
to `.xml`, which is handled and displayed as I would expect an xml
document to be.

---

### Add RSS link to head tag

Add a link rel tag to the head tag to inform user agents that this feed
exists. Though less common than it used to be, browsers and other user
agents can still use this link to find feeds advertised for a webpage.