### PR TITLE
add api_token

### DIFF
--- a/publish/add_episode_from_issue.py
+++ b/publish/add_episode_from_issue.py
@@ -1,3 +1,4 @@
+import os
 import pathlib
 
 import typer
@@ -11,7 +12,11 @@ PCN = Repo("python-community-news", "topics")
 
 def run(issue_number: int):
     template = environment.get_template("page_template.md")
-    current_issue = Issue.from_issue_number(repo=PCN, issue_number=issue_number)
+    current_issue = Issue.from_issue_number(
+        repo=PCN,
+        issue_number=issue_number,
+        api_token=os.environ.get("GITHUB_TOKEN", None),
+    )
     return pathlib.Path(f"site/content/{current_issue.episode_date}.md").write_text(
         template.render(issue=current_issue)
     )


### PR DESCRIPTION
make it so that you can pass the `api_token` through environment variable `GITHUB_TOKEN`.

This is good for manual pushing and testing where you may go pass the API LIMIT unauthenticated.